### PR TITLE
Added a rolling cooldown functionality

### DIFF
--- a/docs/src/js/app.js
+++ b/docs/src/js/app.js
@@ -31,7 +31,7 @@ client.on('chat', (channel, userState, message, self) => {
     const now = new Date();
     const timeSinceLastMesageInMs =  Number(now) - Number(timeLastMessageWasSent);
     const minutesSinceLastMessage = timeSinceLastMesageInMs / 1000 / 60;
-    console.log(minutesSinceLastMessage);
+    
     if ( minutesSinceLastMessage > minutesOfSilenceBeforePlayingNotification){ 
         // Play notification sound.
         notification.play();

--- a/docs/src/js/app.js
+++ b/docs/src/js/app.js
@@ -3,6 +3,10 @@ const channels = [];
 // Default Notification Sound
 let notification = new Audio('./src/audio/notification.mp3');
 
+//Critical variables to avoid sending too many notifications
+const minutesOfSilenceBeforePlayingNotification = 2
+let timeLastMessageWasSent = new Date();
+
 // Client Settings
 const clientOptions = {
     channels,
@@ -23,8 +27,17 @@ client.on('chat', (channel, userState, message, self) => {
     // Return if message from self.
     if (self) return;
 
-    // Play notification sound.
-    notification.play();
+    //check how long it's been since the last message was sent
+    const now = new Date();
+    const timeSinceLastMesageInMs =  Number(now) - Number(timeLastMessageWasSent);
+    const minutesSinceLastMessage = timeSinceLastMesageInMs / 1000 / 60;
+    console.log(minutesSinceLastMessage);
+    if ( minutesSinceLastMessage > minutesOfSilenceBeforePlayingNotification){ 
+        // Play notification sound.
+        notification.play();
+    }
+    //Reset global variable to create a cooldown period
+    timeLastMessageWasSent = now
 });
 
 // Connect To Twitch


### PR DESCRIPTION
As we chatted about over in Rav's stream, a single sound for every message no matter what can be overwhelming and unnecessary. 

But if the app waits for a period of silence in chat first before triggering a sound, then that seems to achieve what this app set out to do (which is a really really nice convenience!)

Right now it's hard set at 2 minutes, but as you can see from the simple structure, it would be pretty easy to create a form field for the user to select how long/short that silent period is, and that could simply adjust that global variable